### PR TITLE
Clean up protos

### DIFF
--- a/proto/spire/api/agent/debug/v1/debug.proto
+++ b/proto/spire/api/agent/debug/v1/debug.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 package spire.agent.debug.v1;
-option go_package = "github.com/spiffe/spire/proto/spire/api/agent/debug/v1;debug";
+option go_package = "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/debug/v1;debugv1";
 
-import "spire/types/spiffeid.proto";
+import "spire/api/types/spiffeid.proto";
 
 service Debug {
     // Get information about SPIRE agent
@@ -15,10 +15,10 @@ message GetInfoRequest {
 message GetInfoResponse {
     message Cert {
         // Cerfificate SPIFFE ID
-        spire.types.SPIFFEID id = 1;
+        spire.api.types.SPIFFEID id = 1;
         // Expiration time
         int64 expires_at = 2;
-        // Subject 
+        // Subject
         string subject = 3;
     }
 

--- a/proto/spire/api/server/agent/v1/agent.proto
+++ b/proto/spire/api/server/agent/v1/agent.proto
@@ -1,15 +1,15 @@
 syntax = "proto3";
 package spire.api.server.agent.v1;
-option go_package = "github.com/spiffe/spire/proto/spire/api/server/agent/v1;agent";
+option go_package = "github.com/spiffe/spire-api-sdk/proto/spire/api/server/agent/v1;agentv1";
 
 import "google/protobuf/empty.proto";
 import "google/protobuf/wrappers.proto";
-import "spire/types/agent.proto";
-import "spire/types/attestation.proto";
-import "spire/types/jointoken.proto";
-import "spire/types/selector.proto";
-import "spire/types/spiffeid.proto";
-import "spire/types/x509svid.proto";
+import "spire/api/types/agent.proto";
+import "spire/api/types/attestation.proto";
+import "spire/api/types/jointoken.proto";
+import "spire/api/types/selector.proto";
+import "spire/api/types/spiffeid.proto";
+import "spire/api/types/x509svid.proto";
 
 service Agent {
     // Count agents.
@@ -25,7 +25,7 @@ service Agent {
     // Gets an agent.
     //
     // The caller must be local or present an admin X509-SVID.
-    rpc GetAgent(GetAgentRequest) returns (spire.types.Agent);
+    rpc GetAgent(GetAgentRequest) returns (spire.api.types.Agent);
 
     // Deletes an agent. The agent can come back into the trust domain through
     // the Issuer AttestAgent RPC.
@@ -57,7 +57,7 @@ service Agent {
     // attestation to join the trust domain.
     //
     // The caller must be local or present an admin X509-SVID.
-    rpc CreateJoinToken(CreateJoinTokenRequest) returns (spire.types.JoinToken);
+    rpc CreateJoinToken(CreateJoinTokenRequest) returns (spire.api.types.JoinToken);
 }
 
 message CountAgentsRequest {
@@ -73,7 +73,7 @@ message ListAgentsRequest {
         string by_attestation_type = 1;
 
         // Filters agents to those satisfying the selector match.
-        spire.types.SelectorMatch by_selector_match = 2;
+        spire.api.types.SelectorMatch by_selector_match = 2;
 
         // Filters agents to those that are banned.
         google.protobuf.BoolValue by_banned = 3;
@@ -83,7 +83,7 @@ message ListAgentsRequest {
     Filter filter = 1;
 
     // An output mask indicating which agent fields are set in the response.
-    spire.types.AgentMask output_mask = 2;
+    spire.api.types.AgentMask output_mask = 2;
 
     // The maximum number of results to return. The server may further
     // constrain this value, or if zero, choose its own.
@@ -95,7 +95,7 @@ message ListAgentsRequest {
 
 message ListAgentsResponse {
     // The agents.
-    repeated spire.types.Agent agents = 1;
+    repeated spire.api.types.Agent agents = 1;
 
     // The page token for the next request. Empty if there are no more results.
     // This field should be checked by clients even when a page_size was not
@@ -105,26 +105,26 @@ message ListAgentsResponse {
 
 message GetAgentRequest {
     // Required. The SPIFFE ID of the agent.
-    spire.types.SPIFFEID id = 1;
+    spire.api.types.SPIFFEID id = 1;
 
     // An output mask indicating which agent fields are set in the response.
-    spire.types.AgentMask output_mask = 2;
+    spire.api.types.AgentMask output_mask = 2;
 }
 
 message DeleteAgentRequest {
     // Required. The SPIFFE ID of the agent.
-    spire.types.SPIFFEID id = 1;
+    spire.api.types.SPIFFEID id = 1;
 }
 
 message BanAgentRequest {
     // Required. The SPIFFE ID of the agent.
-    spire.types.SPIFFEID id = 1;
+    spire.api.types.SPIFFEID id = 1;
 }
 
 message AttestAgentRequest {
     message Params {
         // Required. The attestation data.
-        spire.types.AttestationData data = 1;
+        spire.api.types.AttestationData data = 1;
 
         // Required. The X509-SVID parameters.
         AgentX509SVIDParams params = 2;
@@ -144,7 +144,7 @@ message AttestAgentRequest {
 message AttestAgentResponse {
     message Result {
         // The agent X509-SVID.
-        spire.types.X509SVID svid = 1;
+        spire.api.types.X509SVID svid = 1;
     }
 
     oneof step {
@@ -164,7 +164,7 @@ message RenewAgentRequest {
 
 message RenewAgentResponse {
     // The renewed X509-SVID
-    spire.types.X509SVID svid = 1;
+    spire.api.types.X509SVID svid = 1;
 }
 
 message CreateJoinTokenRequest {
@@ -178,7 +178,7 @@ message CreateJoinTokenRequest {
     // An optional SPIFFE ID to assign to the agent beyond that given by
     // join token attestation. If set, this results in an entry being created
     // that maps the attestation assigned agent ID to this ID.
-    spire.types.SPIFFEID agent_id = 3;
+    spire.api.types.SPIFFEID agent_id = 3;
 }
 
 message AgentX509SVIDParams {

--- a/proto/spire/api/server/bundle/v1/bundle.proto
+++ b/proto/spire/api/server/bundle/v1/bundle.proto
@@ -1,9 +1,9 @@
 syntax = "proto3";
 package spire.api.server.bundle.v1;
-option go_package = "github.com/spiffe/spire/proto/spire/api/server/bundle/v1;bundle";
+option go_package = "github.com/spiffe/spire-api-sdk/proto/spire/api/server/bundle/v1;bundlev1";
 
-import "spire/types/bundle.proto";
-import "spire/types/status.proto";
+import "spire/api/types/bundle.proto";
+import "spire/api/types/status.proto";
 
 service Bundle {
     // Count bundles.
@@ -14,7 +14,7 @@ service Bundle {
     // Gets the bundle for the trust domain of the server.
     //
     // The RPC does not require authentication.
-    rpc GetBundle(GetBundleRequest) returns (spire.types.Bundle);
+    rpc GetBundle(GetBundleRequest) returns (spire.api.types.Bundle);
 
     // Append to the bundle. Items specified in the bundle in the request are
     // appended to the existing bundle. If the bundle does not exist, NOT_FOUND
@@ -22,7 +22,7 @@ service Bundle {
     // bundle for the trust domain of the SPIRE server.
     //
     // The caller must be local or present an admin X509-SVID.
-    rpc AppendBundle(AppendBundleRequest) returns (spire.types.Bundle);
+    rpc AppendBundle(AppendBundleRequest) returns (spire.api.types.Bundle);
 
     // Publishes a downstream JWT authority to the SPIRE server. If the server
     // is itself a downstream server (i.e. configured with an UpstreamAuthority
@@ -42,7 +42,7 @@ service Bundle {
     // Gets a federated bundle. If the bundle does not exist, NOT_FOUND is returned.
     //
     // The caller must be local or present an admin or an active agent X509-SVID.
-    rpc GetFederatedBundle(GetFederatedBundleRequest) returns (spire.types.Bundle);
+    rpc GetFederatedBundle(GetFederatedBundleRequest) returns (spire.api.types.Bundle);
 
     // Batch creates one or more federated bundles.
     //
@@ -75,33 +75,33 @@ message CountBundlesResponse {
 
 message GetBundleRequest {
     // An output mask indicating which bundle fields are set in the response.
-    spire.types.BundleMask output_mask = 1;
+    spire.api.types.BundleMask output_mask = 1;
 }
 
 message AppendBundleRequest {
     // X.509 authorities to append.
-    repeated spire.types.X509Certificate x509_authorities = 1;
+    repeated spire.api.types.X509Certificate x509_authorities = 1;
 
     // JWT authorities to append.
-    repeated spire.types.JWTKey jwt_authorities = 2;
+    repeated spire.api.types.JWTKey jwt_authorities = 2;
 
     // An output mask indicating which bundle fields are set in the response.
-    spire.types.BundleMask output_mask = 3;
+    spire.api.types.BundleMask output_mask = 3;
 }
 
 message PublishJWTAuthorityRequest {
     // Required. The JWT authority to publish.
-    spire.types.JWTKey jwt_authority = 1;
+    spire.api.types.JWTKey jwt_authority = 1;
 }
 
 message PublishJWTAuthorityResponse {
     // The JWT authorities for the trust domain.
-    repeated spire.types.JWTKey jwt_authorities = 1;
+    repeated spire.api.types.JWTKey jwt_authorities = 1;
 }
 
 message ListFederatedBundlesRequest {
     // An output mask indicating which bundle fields are set in the response.
-    spire.types.BundleMask output_mask = 1;
+    spire.api.types.BundleMask output_mask = 1;
 
     // The maximum number of results to return. The server may further
     // constrain this value, or if zero, choose its own.
@@ -113,7 +113,7 @@ message ListFederatedBundlesRequest {
 
 message ListFederatedBundlesResponse {
     // The bundles.
-    repeated spire.types.Bundle bundles = 1;
+    repeated spire.api.types.Bundle bundles = 1;
 
     // The page token for the next request. Empty if there are no more results.
     // This field should be checked by clients even when a page_size was not
@@ -126,24 +126,24 @@ message GetFederatedBundleRequest {
     string trust_domain = 1;
 
     // An output mask indicating which bundle fields are set in the response.
-    spire.types.BundleMask output_mask = 2;
+    spire.api.types.BundleMask output_mask = 2;
 }
 
 message BatchCreateFederatedBundleRequest {
     // The bundles to be created.
-    repeated spire.types.Bundle bundle = 1;
+    repeated spire.api.types.Bundle bundle = 1;
 
     // An output mask indicating which bundle fields are set in the response.
-    spire.types.BundleMask output_mask = 2;
+    spire.api.types.BundleMask output_mask = 2;
 }
 
 message BatchCreateFederatedBundleResponse {
     message Result {
         // The status of creating the bundle.
-        spire.types.Status status = 1;
+        spire.api.types.Status status = 1;
 
         // The bundle that was created. This will be set if the status is OK.
-        spire.types.Bundle bundle = 2;
+        spire.api.types.Bundle bundle = 2;
     }
 
     // Result for each bundle in the request (order is maintained).
@@ -152,22 +152,22 @@ message BatchCreateFederatedBundleResponse {
 
 message BatchUpdateFederatedBundleRequest {
     // The bundles to be updated.
-    repeated spire.types.Bundle bundle = 1;
+    repeated spire.api.types.Bundle bundle = 1;
 
     // An input mask indicating which bundle fields should be updated.
-    spire.types.BundleMask input_mask = 2;
+    spire.api.types.BundleMask input_mask = 2;
 
     // An output mask indicating which bundle fields are set in the response.
-    spire.types.BundleMask output_mask = 3;
+    spire.api.types.BundleMask output_mask = 3;
 }
 
 message BatchUpdateFederatedBundleResponse {
     message Result {
         // The status of updating the bundle.
-        spire.types.Status status = 1;
+        spire.api.types.Status status = 1;
 
         // The bundle that was updated. This will be set if the status is OK.
-        spire.types.Bundle bundle = 2;
+        spire.api.types.Bundle bundle = 2;
     }
 
     // Result for each bundle in the request (order is maintained).
@@ -176,19 +176,19 @@ message BatchUpdateFederatedBundleResponse {
 
 message BatchSetFederatedBundleRequest {
     // The bundles to be upserted.
-    repeated spire.types.Bundle bundle = 1;
+    repeated spire.api.types.Bundle bundle = 1;
 
     // An output mask indicating which bundle fields are set in the response.
-    spire.types.BundleMask output_mask = 2;
+    spire.api.types.BundleMask output_mask = 2;
 }
 
 message BatchSetFederatedBundleResponse {
     message Result {
         // The status of upserting the bundle.
-        spire.types.Status status = 1;
+        spire.api.types.Status status = 1;
 
         // The bundle that was upserted. This will be set if the status is OK.
-        spire.types.Bundle bundle = 2;
+        spire.api.types.Bundle bundle = 2;
     }
 
     // Result for each bundle in the request (order is maintained).
@@ -210,14 +210,14 @@ message BatchDeleteFederatedBundleRequest {
     // The trust domain names (e.g., "example.org") of the bundles to delete.
     repeated string trust_domains = 1;
 
-    // The deletion mode selected  
+    // The deletion mode selected
     Mode mode = 2;
 }
 
 message BatchDeleteFederatedBundleResponse {
     message Result {
         // The status of deleting the bundle.
-        spire.types.Status status = 1;
+        spire.api.types.Status status = 1;
 
         // The trust domain name (e.g., "example.org") of the bundle that was
         // deleted.

--- a/proto/spire/api/server/debug/v1/debug.proto
+++ b/proto/spire/api/server/debug/v1/debug.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 package spire.api.server.debug.v1;
-option go_package = "github.com/spiffe/spire/proto/spire/api/server/debug/v1;debug";
+option go_package = "github.com/spiffe/spire-api-sdk/proto/spire/api/server/debug/v1;debugv1";
 
-import "spire/types/spiffeid.proto";
+import "spire/api/types/spiffeid.proto";
 
 service Debug {
     // Get information about SPIRE server
@@ -15,11 +15,11 @@ message GetInfoRequest {
 message GetInfoResponse {
     message Cert {
         // Certificate SPIFFE ID
-    	spire.types.SPIFFEID id = 1;
-	// Expiration time
-	int64 expires_at = 2;
-	// Subject
-	string subject = 3;
+        spire.api.types.SPIFFEID id = 1;
+        // Expiration time
+        int64 expires_at = 2;
+        // Subject
+        string subject = 3;
     }
 
     // Server SVID chain

--- a/proto/spire/api/server/entry/v1/entry.proto
+++ b/proto/spire/api/server/entry/v1/entry.proto
@@ -1,12 +1,12 @@
 syntax = "proto3";
 package spire.api.server.entry.v1;
-option go_package = "github.com/spiffe/spire/proto/spire/api/server/entry/v1;entry";
+option go_package = "github.com/spiffe/spire-api-sdk/proto/spire/api/server/entry/v1;entryv1";
 
-import "spire/types/entry.proto";
-import "spire/types/federateswith.proto";
-import "spire/types/selector.proto";
-import "spire/types/spiffeid.proto";
-import "spire/types/status.proto";
+import "spire/api/types/entry.proto";
+import "spire/api/types/federateswith.proto";
+import "spire/api/types/selector.proto";
+import "spire/api/types/spiffeid.proto";
+import "spire/api/types/status.proto";
 
 // Manages registration entries stored by the SPIRE Server.
 service Entry {
@@ -23,7 +23,7 @@ service Entry {
     // Gets an entry. If the entry does not exist, NOT_FOUND is returned.
     //
     // The caller must be local or present an admin X509-SVID.
-    rpc GetEntry(GetEntryRequest) returns (spire.types.Entry);
+    rpc GetEntry(GetEntryRequest) returns (spire.api.types.Entry);
 
     // Batch creates one or more entries.
     //
@@ -56,17 +56,17 @@ message CountEntriesResponse {
 
 message ListEntriesRequest {
     message Filter {
-        spire.types.SPIFFEID by_spiffe_id = 1;
-        spire.types.SPIFFEID by_parent_id = 2;
-        spire.types.SelectorMatch by_selectors = 3;
-        spire.types.FederatesWithMatch by_federates_with = 4; 
+        spire.api.types.SPIFFEID by_spiffe_id = 1;
+        spire.api.types.SPIFFEID by_parent_id = 2;
+        spire.api.types.SelectorMatch by_selectors = 3;
+        spire.api.types.FederatesWithMatch by_federates_with = 4;
     }
 
     // Filters the entries returned in the response.
     Filter filter = 1;
 
     // An output mask indicating the entry fields set in the response.
-    spire.types.EntryMask output_mask = 2;
+    spire.api.types.EntryMask output_mask = 2;
 
     // The maximum number of results to return. The server may further
     // constrain this value, or if zero, choose its own.
@@ -78,7 +78,7 @@ message ListEntriesRequest {
 
 message ListEntriesResponse {
     // The list of entries.
-    repeated spire.types.Entry entries = 1;
+    repeated spire.api.types.Entry entries = 1;
 
     // The page token for the next request. Empty if there are no more results.
     // This field should be checked by clients even when a page_size was not
@@ -91,16 +91,16 @@ message GetEntryRequest {
     string id = 1;
 
     // An output mask indicating the entry fields set in the response.
-    spire.types.EntryMask output_mask = 2;
+    spire.api.types.EntryMask output_mask = 2;
 }
 
 message BatchCreateEntryRequest {
     // The entries to be created. The entry ID field is output only, and will
     // be ignored here.
-    repeated spire.types.Entry entries = 1;
+    repeated spire.api.types.Entry entries = 1;
 
     // An output mask indicating the entry fields set in the response.
-    spire.types.EntryMask output_mask = 2;
+    spire.api.types.EntryMask output_mask = 2;
 }
 
 message BatchCreateEntryResponse {
@@ -108,13 +108,13 @@ message BatchCreateEntryResponse {
         // The status of creating the entry. If status code will be
         // ALREADY_EXISTS if a similar entry already exists. An entry is
         // similar if it has the same spiffe_id, parent_id, and selectors.
-        spire.types.Status status = 1;
+        spire.api.types.Status status = 1;
 
         // The entry that was created (.e.g status code is OK) or that already
         // exists (i.e. status code is ALREADY_EXISTS).
         //
         // If the status code is any other value, this field will not be set.
-        spire.types.Entry entry = 2;
+        spire.api.types.Entry entry = 2;
     }
 
     // Result for each entry in the request (order is maintained).
@@ -123,24 +123,24 @@ message BatchCreateEntryResponse {
 
 message BatchUpdateEntryRequest {
     // The entries to be updated.
-    repeated spire.types.Entry entries = 1;
+    repeated spire.api.types.Entry entries = 1;
 
     // An input mask indicating what entry fields should be updated.
-    spire.types.EntryMask input_mask = 2;
+    spire.api.types.EntryMask input_mask = 2;
 
     // An output mask indicating what entry fields are set in the response.
-    spire.types.EntryMask output_mask = 3;
+    spire.api.types.EntryMask output_mask = 3;
 }
 
 message BatchUpdateEntryResponse {
     message Result {
         // The status of creating the entry.
-        spire.types.Status status = 1;
+        spire.api.types.Status status = 1;
 
         // The entry that was updated. If the status is OK, it will be the
         // entry that was updated. If the status is any other value, this field
         // will not be set.
-        spire.types.Entry entry = 2;
+        spire.api.types.Entry entry = 2;
     }
 
     // Result for each entry in the request (order is maintained).
@@ -155,7 +155,7 @@ message BatchDeleteEntryRequest {
 message BatchDeleteEntryResponse {
     message Result {
         // The status of creating the entry.
-        spire.types.Status status = 1;
+        spire.api.types.Status status = 1;
 
         // The ID of the entry that was deleted.
         string id = 2;
@@ -167,10 +167,10 @@ message BatchDeleteEntryResponse {
 
 message GetAuthorizedEntriesRequest {
     // An output mask indicating which fields are set in the response.
-    spire.types.EntryMask output_mask = 1;
+    spire.api.types.EntryMask output_mask = 1;
 }
 
 message GetAuthorizedEntriesResponse {
     // The authorized entries.
-    repeated spire.types.Entry entries = 1;
+    repeated spire.api.types.Entry entries = 1;
 }

--- a/proto/spire/api/server/svid/v1/svid.proto
+++ b/proto/spire/api/server/svid/v1/svid.proto
@@ -1,11 +1,11 @@
 syntax = "proto3";
 package spire.api.server.svid.v1;
-option go_package = "github.com/spiffe/spire/proto/spire/api/server/svid/v1;svid";
+option go_package = "github.com/spiffe/spire-api-sdk/proto/spire/api/server/svid/v1;svidv1";
 
-import "spire/types/jwtsvid.proto";
-import "spire/types/spiffeid.proto";
-import "spire/types/status.proto";
-import "spire/types/x509svid.proto";
+import "spire/api/types/jwtsvid.proto";
+import "spire/api/types/spiffeid.proto";
+import "spire/api/types/status.proto";
+import "spire/api/types/x509svid.proto";
 
 service SVID {
     // Mints a one-off X509-SVID outside of the normal node/workload
@@ -54,12 +54,12 @@ message MintX509SVIDRequest {
 
 message MintX509SVIDResponse {
     // The newly issued X509-SVID.
-    spire.types.X509SVID svid = 1;
+    spire.api.types.X509SVID svid = 1;
 }
 
 message MintJWTSVIDRequest {
     // Required. SPIFFE ID of the JWT-SVID.
-    spire.types.SPIFFEID id = 1;
+    spire.api.types.SPIFFEID id = 1;
 
     // Required. List of audience claims to include in the JWT-SVID. At least one must
     // be set.
@@ -74,7 +74,7 @@ message MintJWTSVIDRequest {
 
 message MintJWTSVIDResponse {
     // The newly issued JWT-SVID.
-    spire.types.JWTSVID svid = 1;
+    spire.api.types.JWTSVID svid = 1;
 }
 
 message BatchNewX509SVIDRequest {
@@ -86,10 +86,10 @@ message BatchNewX509SVIDRequest {
 message BatchNewX509SVIDResponse {
     message Result {
         // The status of creating the X509-SVID.
-        spire.types.Status status = 1;
+        spire.api.types.Status status = 1;
 
         // The newly created X509-SVID. This will be set if the status is OK.
-        spire.types.X509SVID svid = 2;
+        spire.api.types.X509SVID svid = 2;
     }
 
     // Result for each X509-SVID requested (order is maintained).
@@ -107,7 +107,7 @@ message NewJWTSVIDRequest {
 
 message NewJWTSVIDResponse {
     // The newly issued JWT-SVID
-    spire.types.JWTSVID svid = 1;
+    spire.api.types.JWTSVID svid = 1;
 }
 
 message NewDownstreamX509CARequest {

--- a/proto/spire/api/types/agent.proto
+++ b/proto/spire/api/types/agent.proto
@@ -1,13 +1,13 @@
 syntax = "proto3";
-package spire.types;
-option go_package = "github.com/spiffe/spire/proto/spire/types";
+package spire.api.types;
+option go_package = "github.com/spiffe/spire-api-sdk/proto/spire/api/types";
 
-import "spire/types/selector.proto";
-import "spire/types/spiffeid.proto";
+import "spire/api/types/selector.proto";
+import "spire/api/types/spiffeid.proto";
 
 message Agent {
     // Output only. SPIFFE ID of the agent.
-    spire.types.SPIFFEID id = 1;
+    spire.api.types.SPIFFEID id = 1;
 
     // Output only. The method by which the agent attested.
     string attestation_type = 2;
@@ -19,7 +19,7 @@ message Agent {
     int64 x509svid_expires_at = 4;
 
     // Output only. The selectors attributed to the agent during attestation.
-    repeated spire.types.Selector selectors = 5;
+    repeated spire.api.types.Selector selectors = 5;
 
     // Output only. Whether or not the agent is banned.
     bool banned = 6;

--- a/proto/spire/api/types/attestation.proto
+++ b/proto/spire/api/types/attestation.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
-package spire.types;
-option go_package = "github.com/spiffe/spire/proto/spire/types";
+package spire.api.types;
+option go_package = "github.com/spiffe/spire-api-sdk/proto/spire/api/types";
 
 message AttestationData {
     // The type of attestation data. This is typically the name of the plugin

--- a/proto/spire/api/types/bundle.proto
+++ b/proto/spire/api/types/bundle.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
-
-package spire.types;
-option go_package = "github.com/spiffe/spire/proto/spire/types";
+package spire.api.types;
+option go_package = "github.com/spiffe/spire-api-sdk/proto/spire/api/types";
 
 message Bundle {
     // The name of the trust domain the bundle belongs to (e.g., "example.org").

--- a/proto/spire/api/types/entry.proto
+++ b/proto/spire/api/types/entry.proto
@@ -1,28 +1,28 @@
 syntax = "proto3";
-package spire.types;
-option go_package = "github.com/spiffe/spire/proto/spire/types";
+package spire.api.types;
+option go_package = "github.com/spiffe/spire-api-sdk/proto/spire/api/types";
 
-import "spire/types/selector.proto";
-import "spire/types/spiffeid.proto";
+import "spire/api/types/selector.proto";
+import "spire/api/types/spiffeid.proto";
 
 message Entry {
     // Globally unique ID for the entry.
     string id = 1;
 
     // The SPIFFE ID of the identity described by this entry.
-    spire.types.SPIFFEID spiffe_id = 2;
+    spire.api.types.SPIFFEID spiffe_id = 2;
 
     // Who the entry is delegated to. If the entry describes a node, this is
     // set to the SPIFFE ID of the SPIRE server of the trust domain (e.g.
     // spiffe://example.org/spire/server). Otherwise, it will be set to a node
     // SPIFFE ID.
-    spire.types.SPIFFEID parent_id = 3;
+    spire.api.types.SPIFFEID parent_id = 3;
 
     // The selectors which identify which entities match this entry. If this is
     // an entry for a node, these selectors represent selectors produced by
     // node attestation. Otherwise, these selectors represent those produced by
     // workload attestation.
-    repeated spire.types.Selector selectors = 4;
+    repeated spire.api.types.Selector selectors = 4;
 
     // The time to live for identities issued for this entry (in seconds).
     int32 ttl = 5;

--- a/proto/spire/api/types/federateswith.proto
+++ b/proto/spire/api/types/federateswith.proto
@@ -1,10 +1,10 @@
 syntax = "proto3";
-package spire.types;
-option go_package = "github.com/spiffe/spire/proto/spire/types";
+package spire.api.types;
+option go_package = "github.com/spiffe/spire-api-sdk/proto/spire/api/types";
 
 message FederatesWithMatch {
     enum MatchBehavior {
-        // Indicates that the federated trust domains in this match are 
+        // Indicates that the federated trust domains in this match are
         // equal to the candidate trust domains, independent of ordering.
         MATCH_EXACT = 0;
 

--- a/proto/spire/api/types/jointoken.proto
+++ b/proto/spire/api/types/jointoken.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
-package spire.types;
-option go_package = "github.com/spiffe/spire/proto/spire/types";
+package spire.api.types;
+option go_package = "github.com/spiffe/spire-api-sdk/proto/spire/api/types";
 
 message JoinToken {
     // The value of the token.

--- a/proto/spire/api/types/jwtsvid.proto
+++ b/proto/spire/api/types/jwtsvid.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
-package spire.types;
-option go_package = "github.com/spiffe/spire/proto/spire/types";
+package spire.api.types;
+option go_package = "github.com/spiffe/spire-api-sdk/proto/spire/api/types";
 
-import "spire/types/spiffeid.proto";
+import "spire/api/types/spiffeid.proto";
 
 // JWT SPIFFE Verifiable Identity Document. It contains the raw JWT token
 // as well as a few denormalized fields for convenience.
@@ -11,7 +11,7 @@ message JWTSVID {
     string token = 1;
 
     // The SPIFFE ID of the JWT-SVID.
-    spire.types.SPIFFEID id = 2;
+    spire.api.types.SPIFFEID id = 2;
 
     // Expiration timestamp (seconds since Unix epoch).
     int64 expires_at = 3;

--- a/proto/spire/api/types/selector.proto
+++ b/proto/spire/api/types/selector.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
-package spire.types;
-option go_package = "github.com/spiffe/spire/proto/spire/types";
+package spire.api.types;
+option go_package = "github.com/spiffe/spire-api-sdk/proto/spire/api/types";
 
 message Selector {
     // The type of the selector. This is typically the name of the plugin that

--- a/proto/spire/api/types/spiffeid.proto
+++ b/proto/spire/api/types/spiffeid.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
-package spire.types;
-option go_package = "github.com/spiffe/spire/proto/spire/types";
+package spire.api.types;
+option go_package = "github.com/spiffe/spire-api-sdk/proto/spire/api/types";
 
 // A SPIFFE ID, consisting of the trust domain name and a path portions of
 // the SPIFFE ID URI.

--- a/proto/spire/api/types/status.proto
+++ b/proto/spire/api/types/status.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
-package spire.types;
-option go_package = "github.com/spiffe/spire/proto/spire/types";
+package spire.api.types;
+option go_package = "github.com/spiffe/spire-api-sdk/proto/spire/api/types";
 
 message Status {
     // A status code, which should be an enum value of google.rpc.Code.

--- a/proto/spire/api/types/x509svid.proto
+++ b/proto/spire/api/types/x509svid.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
-package spire.types;
-option go_package = "github.com/spiffe/spire/proto/spire/types";
+package spire.api.types;
+option go_package = "github.com/spiffe/spire-api-sdk/proto/spire/api/types";
 
-import "spire/types/spiffeid.proto";
+import "spire/api/types/spiffeid.proto";
 
 // X.509 SPIFFE Verifiable Identity Document. It contains the raw X.509
 // certificate data as well as a few denormalized fields for convenience.
@@ -12,7 +12,7 @@ message X509SVID {
     repeated bytes cert_chain = 1;
 
     // SPIFFE ID of the SVID.
-    spire.types.SPIFFEID id = 2;
+    spire.api.types.SPIFFEID id = 2;
 
     // Expiration timestamp (seconds since Unix epoch).
     int64 expires_at = 3;


### PR DESCRIPTION
- Fixed up go module paths to point to this repository instead of SPIRE
- Changed go package names for easier importing via `goimports` (i.e.`.../bundle/v1` imports as `bundlev1` instead of `bundle`)
- Renames spire/types ==> spire/api/types to cleanly namespace types related to the API
- Removed some bad trailing whitespace and mixed tabs/spaces