### PR TITLE
Update trust domain proto messages to support static federation relationships

### DIFF
--- a/proto/spire/api/server/trustdomain/v1/trustdomain.proto
+++ b/proto/spire/api/server/trustdomain/v1/trustdomain.proto
@@ -56,6 +56,10 @@ message ListFederationRelationshipsRequest {
 
     // The next_page_token value returned from a previous request, if any.
     string page_token = 3;
+
+    // If true, static federation relationships defined in the SPIRE server
+    // configuration file are included in the response.
+    bool include_static = 4;
 }
 
 message ListFederationRelationshipsResponse {
@@ -73,9 +77,13 @@ message GetFederationRelationshipRequest {
     // (e.g., "example.org").
     string trust_domain = 1;
 
+    // If true, it returns the static federation relationship defined in the
+    // SPIRE server configuration file.
+    bool include_static = 2;
+
     // An output mask indicating which federation relationship fields
     // are set in the response.
-    spire.api.types.FederationRelationshipMask output_mask = 2;
+    spire.api.types.FederationRelationshipMask output_mask = 3;
 }
 
 message BatchCreateFederationRelationshipRequest {

--- a/proto/spire/api/types/federationrelationship.proto
+++ b/proto/spire/api/types/federationrelationship.proto
@@ -12,13 +12,18 @@ message FederationRelationship {
     // bundle to federate with. Must use the HTTPS protocol.
     string bundle_endpoint_url = 2;
 
+    // If true, it indicates that the federation relationship is static. Static
+    // federation relationships are those defined in the SPIRE server
+    // configuration file.
+    bool static = 3;
+
     // Required. The endpoint profile type.
     oneof bundle_endpoint_profile {
         // Use Web PKI endpoint profile. 
-        HTTPSWebProfile https_web = 3;
+        HTTPSWebProfile https_web = 4;
 
         // Use SPIFFE Authentication endpoint profile.
-        HTTPSSPIFFEProfile https_spiffe = 4;
+        HTTPSSPIFFEProfile https_spiffe = 5;
     }
 }
 


### PR DESCRIPTION
This PR updates the trustdomain proto messages to support static federation relationships according to the discussion in: [#2260](https://github.com/spiffe/spire/issues/2260)

Signed-off-by: Marcos Yedro <marcosyedro@gmail.com>