### PR TITLE
Remove extraneous comment in proto file

### DIFF
--- a/proto/spire/api/agent/delegatedidentity/v1/delegatedidentity.proto
+++ b/proto/spire/api/agent/delegatedidentity/v1/delegatedidentity.proto
@@ -20,9 +20,6 @@ service DelegatedIdentity {
     // The lifetime of the subscription aligns to the lifetime of the stream.
     rpc SubscribeToX509SVIDs(SubscribeToX509SVIDsRequest) returns (stream SubscribeToX509SVIDsResponse);
 
-    // Subscribe to get X.509-SVIDs for workloads that match the given selectors.
-    // The lifetime of the subscription aligns to the lifetime of the stream.
-    //
     // Subscribe to get local and all federated bundles.
     // The lifetime of the subscription aligns to the lifetime of the stream.
     rpc SubscribeToX509Bundles(SubscribeToX509BundlesRequest) returns (stream SubscribeToX509BundlesResponse);

--- a/proto/spire/api/agent/delegatedidentity/v1/delegatedidentity_grpc.pb.go
+++ b/proto/spire/api/agent/delegatedidentity/v1/delegatedidentity_grpc.pb.go
@@ -20,9 +20,6 @@ type DelegatedIdentityClient interface {
 	// Subscribe to get X.509-SVIDs for workloads that match the given selectors.
 	// The lifetime of the subscription aligns to the lifetime of the stream.
 	SubscribeToX509SVIDs(ctx context.Context, in *SubscribeToX509SVIDsRequest, opts ...grpc.CallOption) (DelegatedIdentity_SubscribeToX509SVIDsClient, error)
-	// Subscribe to get X.509-SVIDs for workloads that match the given selectors.
-	// The lifetime of the subscription aligns to the lifetime of the stream.
-	//
 	// Subscribe to get local and all federated bundles.
 	// The lifetime of the subscription aligns to the lifetime of the stream.
 	SubscribeToX509Bundles(ctx context.Context, in *SubscribeToX509BundlesRequest, opts ...grpc.CallOption) (DelegatedIdentity_SubscribeToX509BundlesClient, error)
@@ -154,9 +151,6 @@ type DelegatedIdentityServer interface {
 	// Subscribe to get X.509-SVIDs for workloads that match the given selectors.
 	// The lifetime of the subscription aligns to the lifetime of the stream.
 	SubscribeToX509SVIDs(*SubscribeToX509SVIDsRequest, DelegatedIdentity_SubscribeToX509SVIDsServer) error
-	// Subscribe to get X.509-SVIDs for workloads that match the given selectors.
-	// The lifetime of the subscription aligns to the lifetime of the stream.
-	//
 	// Subscribe to get local and all federated bundles.
 	// The lifetime of the subscription aligns to the lifetime of the stream.
 	SubscribeToX509Bundles(*SubscribeToX509BundlesRequest, DelegatedIdentity_SubscribeToX509BundlesServer) error


### PR DESCRIPTION
Remove what appears to be a copy/paste error in the comment for `rpc SubscribeToX509Bundles(...)`. The removed text appears to be copied from `rpc SubscribeToX509SVIDs(...)` but is irrelevant in the current context.